### PR TITLE
CLI-468 Print the latest versions stream in json format through appc use command

### DIFF
--- a/lib/use.js
+++ b/lib/use.js
@@ -22,6 +22,7 @@ function use(opts, callback, wantVersion) {
 		util.requestJSON(url, function(err,result){
 			util.stopSpinner();
 			if (err) { return callback(errorlib.createError('com.appcelerator.install.use.download.error',err.message||String(err))); }
+			debug('versions returned from registry:', result);
 			if (result && result.key) {
 				result = result[result.key];
 			}
@@ -33,21 +34,34 @@ function use(opts, callback, wantVersion) {
 				var latest = result[0].version;
 				return use(opts, callback, latest);
 			}
-			console.log(chalk.white.bold.underline('The following versions are available:\n'));
 			var theversion = util.getActiveVersion();
-			result.forEach(function(entry){
-				var ver = entry.version;
-				var msg = util.getInstallBinary(opts,ver) ? 'Installed' : 'Not Installed';
-				if (result.latest === ver) {
-					msg+=chalk.white.bold(' (Latest)');
-				}
-				if (theversion && theversion===ver) {
-					msg+=chalk.red(' (Active)');
-				}
-				var date = entry.date ? chalk.grey(util.pad(new Date(Date.parse(entry.date)),15)) : '';
-				console.log(chalk.yellow(util.pad(ver, 10))+' '+chalk.cyan(util.pad(msg, 40))+' '+date);
-			});
-			console.log('');
+			// Is this JSON output ?
+			if ('json' === util.parseOpts(opts)['o']) {
+				var obj = {
+					versions: [],
+					latest: result[0].version,
+					active: theversion
+				};
+				obj.versions = Object.keys(result).map(function(value, index){
+					return result[index].version;
+				});
+				console.log(JSON.stringify(obj, null, '\t'));
+			} else {
+				console.log(chalk.white.bold.underline('The following versions are available:\n'));
+				result.forEach(function(entry){
+					var ver = entry.version;
+					var msg = util.getInstallBinary(opts,ver) ? 'Installed' : 'Not Installed';
+					if (result.latest === ver) {
+						msg+=chalk.white.bold(' (Latest)');
+					}
+					if (theversion && theversion===ver) {
+						msg+=chalk.red(' (Active)');
+					}
+					var date = entry.date ? chalk.grey(util.pad(new Date(Date.parse(entry.date)),15)) : '';
+					console.log(chalk.yellow(util.pad(ver, 10))+' '+chalk.cyan(util.pad(msg, 40))+' '+date);
+				});
+				console.log('');
+			}
 			process.exit(0);
 		});
 	}


### PR DESCRIPTION
Added a new output format for ``appc use`` command to print the list of versions in JSON format. It also prints the latest and active version in the JSON format. 