### PR TITLE
[CLI-485] Fix version file not being set correctly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -131,6 +131,9 @@ function getNpmCacheDirectory() {
 function writeVersion(version) {
 	var versionFile = getVersionFile();
 	debug('writing version: %s to %s',version,versionFile);
+	if (fs.existsSync(versionFile)) {
+		fs.unlinkSync(versionFile);
+	}
 	fs.writeFileSync(versionFile,version);
 }
 


### PR DESCRIPTION
- In some cases the ```.version``` file does not get set correctly upon re-writing the file

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-485)