### PR TITLE
[CLI-580] Set version after installation has completed

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -391,14 +391,13 @@ function install (installDir, opts, cb) {
 					failed = false;
 
 					// make the new version active
-					if (!opts.version && (opts.setup || opts.use)) {
+					if (opts.setup || opts.use) {
 						util.writeVersion(version);
 					}
 
 					// if this is a setup, then run the setup after the install
 					if (opts.setup) {
 						debug('after compileNativeModules, setup is set');
-						util.writeVersion(version);
 						return runSetup(installBin, opts, cb);
 					}
 

--- a/lib/use.js
+++ b/lib/use.js
@@ -70,9 +70,9 @@ function use(opts, callback, wantVersion) {
 		// see if we have this version
 		installBin = util.getInstallBinary(opts, version);
 		// we already have this version, so we just need to write our version file and exit
-		util.writeVersion(version);
 		if (installBin && !opts.force) {
 			debug('making %s your active version, dir %s',version,installBin);
+			util.writeVersion(version);
 			console.log(chalk.yellow(version)+" is now your active version");
 			process.exit(0);
 		}


### PR DESCRIPTION
- Only set the ```.version``` after the installation has completed

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-580)

_____________________________________

###### TEST CASE
```bash
# Download and install the latest CLI
appc use latest

# Cancel the download by pressing Ctrl+C
# Check if '.version' exists, it shouldn't

# Download and install latest CLI
appc use latest

# Check if '.version' exists, it should
```