### PR TITLE
[CLI-434] Fix progress bar flashing and download performance on Windows

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -89,14 +89,16 @@ function download(quiet, force, wantVersion, tmpfile, stream, location, callback
 
 			bar = (!nobanner && process.stdout.isTTY && !process.env.TRAVIS) &&
 				new ProgressBar('Downloading [:bar] :percent :etas', {
-					complete: chalk.green(util.isWindows()?'█':'▤'),
-					incomplete: chalk.gray(' '),
+					complete: util.isWindows() ? '█' : chalk.green('▤'),
+					incomplete: ' ',
 					width: Math.max(40, Math.round(process.stdout.columns/2)),
 					total: total,
 					clear: true,
 					stream: process.stdout
 			});
-			var count = 0;
+			var count = 0,
+				tickCount = 0,
+				tickDiff = total*0.01;
 
 			util.stopSpinner();
 
@@ -106,7 +108,13 @@ function download(quiet, force, wantVersion, tmpfile, stream, location, callback
 
 			res.on('data', function (chunk) {
 				if (chunk.length) {
-					if (bar) { bar.tick(chunk.length); }
+					if (bar) {
+						tickCount += chunk.length;
+						if (tickCount > tickDiff) {
+							bar.tick(tickCount);
+							tickCount = 0;
+						}
+					}
 					stream.write(chunk);
 					hash.update(chunk);
 					count+=chunk.length;
@@ -126,6 +134,7 @@ function download(quiet, force, wantVersion, tmpfile, stream, location, callback
 
 			res.on('end', function () {
 				debug('download end');
+				if (bar) { bar.tick(tickCount); }
 				stream.end();
 				pendingRequest = null;
 				// check to make sure we downloaded all the bytes we needed too


### PR DESCRIPTION
- Fixes windows progress bar flickering issues
- Improves download performance
- Removed ```chalk.gray``` since colouring a space doesn't do anything

NOTE : I have disabled ```chalk``` colours on the progress bar for Windows. This was causing flickering and download issues.

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-434)