### PR TITLE
[CLI-510] Add ability to remove installed versions

### DIFF
--- a/lib/use.js
+++ b/lib/use.js
@@ -9,16 +9,20 @@
 var util = require('./util'),
 	errorlib = require('./error'),
 	debug = require('debug')('appc:use'),
+	inquirer = require('inquirer'),
+	path = require('path'),
 	chalk = require('chalk');
 
 function use(opts, callback, wantVersion) {
 	var args = util.parseArgs(opts),
 		obj,
+		installBin,
+		remove = opts.r || opts.remove,
 		getLatest = !wantVersion && args.length > 1 && args[1] === 'latest';
 
 	debug('use called with args %o, getLatest=%d', args, getLatest);
 
-	if (args.length > 1 && !getLatest) {
+	if (!remove && args.length > 1 && !getLatest) {
 		var version = opts.version = wantVersion || args[1];
 		// see if we have this version
 		installBin = util.getInstallBinary(opts, version);
@@ -32,6 +36,88 @@ function use(opts, callback, wantVersion) {
 		opts.use = true;
 		// otherwise, we didn't find it, fall through so we can install it
 		return callback();
+	}
+	else if (typeof remove === 'string') {
+		var force = opts.f || opts.force,
+			activeVersion = util.getActiveVersion(),
+			removeVersion = function (version) {
+				if (util.getInstallBinary(opts, version)) {
+					util.waitMessage('\nRemoving version ' + version + ' ... ');
+					// removing active version
+					if (activeVersion === version) {
+						util.writeVersion('');
+					}
+					// delete version folder
+					util.rmdirSyncRecursive(path.join(util.getInstallDir(), version));
+					util.okMessage();
+					console.log(chalk.green.bold('Removed!!'));
+				}
+			};
+
+		// remove all excluding active version
+		if (remove === 'all') {
+			var removeAll = function () {
+				var versions = util.getInstalledVersions();
+				for(i in versions) {
+					var version = versions[i];
+					if (activeVersion === version) continue;
+					removeVersion(version);
+				}
+			}
+			// force remove all
+			if (force) {
+				removeAll();
+			} else {
+				// warn and prompt for confirmation
+				console.log(chalk.red('WARNING! This will permanently remove ALL versions' + (activeVersion ? ' excluding ' + activeVersion : '') + ':'));
+				inquirer.prompt([{
+						type: 'input',
+						name: 'confirm',
+						message: 'Enter \'' + chalk.cyan('yes') + '\' to confirm removal: '
+					}], function(result) {
+						if (result.confirm === 'yes' || result.confirm === 'y') {
+							removeAll();
+						}
+					});
+			}
+
+		// remove using a regular expression
+		} else if (remove === 'regex' && args[1] !== undefined) {
+			var regex = new RegExp(args[1]),
+				versions = util.getInstalledVersions(),
+				removeRegex = function () {
+					for(i in versions) {
+						removeVersion(versions[i]);
+					}
+				};
+			// match regular expression
+			for(var i = versions.length-1;i > 0; i--) {
+				if (!versions[i].match(regex)) {
+					versions.pop();
+					i--;
+				}
+			}
+			// force remove using regular expression
+			if (force) {
+				removeRegex();
+			} else {
+				// warn and prompt for confirmation
+				console.log(chalk.red('WARNING! This will permanently remove:'));
+				for(i in versions) {
+					console.log(chalk.cyan(versions[i]));
+				}
+				inquirer.prompt([{
+						type: 'input',
+						name: 'confirm',
+						message: 'Enter \'' + chalk.cyan('yes') + '\' to confirm removal: '
+					}], function(result) {
+						if (result.confirm === 'yes' || result.confirm === 'y') {
+							removeRegex();
+						}
+					});
+			}
+		}
+		return;
 	}
 
 	util.startSpinner();

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "progress": "1.1.8",
     "request": "^2.55.0",
     "tar": "1.0.3",
+    "inquirer": "0.8.4",
     "which": "1.0.8",
     "semver": "~3.0.1",
     "update-notifier": "^0.5.0"


### PR DESCRIPTION
- Added ```-r``` and ```--remove``` flags to ```appc use``` to allow the removal of installed versions
- Remove all version excluding current version with ```appc use -r all```
- Remove using a regular expression using ```appc use -r regex 5.*```
- To force remove an installation without confirmation the ```-f``` or ```--force``` flag can also be used
- Defined ```installBin``` to prevent memory leak. [Response to this](https://github.com/appcelerator/appc-install/pull/24/files#r30528307)

###### EXAMPLE
```
appc use -r all
WARNING! This will permanently remove ALL versions excluding 5.1.0:
? Enter 'yes' to confirm removal:  y

Removing version 5.2.0-55 ... OK
Removed!!
```
```
appc use -r regex 5.*
WARNING! This will permanently remove:
5.2.0-55
5.1.0
? Enter 'yes' to confirm removal:  y

Removing version 5.2.0-55 ... OK
Removed!!

Removing version 5.1.0 ... OK
Removed!!
```
[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-510)