### PR TITLE
[CLI-600] Allow 'appc use latest' offline

### DIFF
--- a/lib/use.js
+++ b/lib/use.js
@@ -30,10 +30,20 @@ function use(opts, callback, wantVersion) {
 				// looks like we are offline
 				if (err.code === 'ENOTFOUND' || 'ENOENT') {
 					var versions = util.getInstalledVersions();
+					// set active version as latest installed version
+					if (getLatest) {
+						latest = versions[0];
+						installBin = util.getInstallBinary(opts, latest);
+						if (installBin) {
+							debug('making %s your active version, dir %s',latest,installBin);
+							util.writeVersion(latest);
+							console.log(chalk.yellow(latest)+" is now your active version");
+						}
 					// json output
-					if ('json' === util.parseOpts(opts).o) {
+					} else if ('json' === util.parseOpts(opts).o) {
 						obj = util.getVersionJson(versions);
 						console.log(JSON.stringify(obj, null, '\t'));
+					// display installed versions
 					} else {
 						console.log(chalk.white.bold.underline('The following versions are available offline:\n'));
 						util.listVersions(opts, versions);


### PR DESCRIPTION
- Using ``appc use latest``` offline sets the active version as the latest CLI version installed

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-600)