### PR TITLE
REG-55 Support tag versions for publishing appc-cli

### DIFF
--- a/lib/use.js
+++ b/lib/use.js
@@ -14,89 +14,111 @@ var util = require('./util'),
 function use(opts, callback, wantVersion) {
 	var args = util.parseArgs(opts),
 		obj,
-		getLatest = !wantVersion && args.length > 1 && args[1]==='latest';
+		getLatest = !wantVersion && args.length > 1 && args[1] === 'latest';
 
-	debug('use called with args %o, getLatest=%d',args,getLatest);
-	if (args.length < 2 || getLatest) {
-		util.startSpinner();
-		var url = util.makeURL(opts, '/api/appc/list');
-		util.requestJSON(url, function(err,result) {
-			util.stopSpinner();
-			if (err) {
-				// if already an AppCError just return it
-				if (err.name === 'AppCError') {
-					return callback(err);
-				}
-				// looks like we are offline
-				if (err.code === 'ENOTFOUND' || err.code === 'ENOENT') {
-					var versions = util.getInstalledVersions();
-					// set active version as latest installed version
-					if (getLatest) {
-						latest = versions[0];
-						installBin = util.getInstallBinary(opts, latest);
-						if (installBin) {
-							debug('making %s your active version, dir %s',latest,installBin);
-							util.writeVersion(latest);
-							console.log(chalk.yellow(latest)+" is now your active version");
-						}
-					// json output
-					} else if ('json' === util.parseOpts(opts).o) {
-						obj = util.getVersionJson(versions);
-						console.log(JSON.stringify(obj, null, '\t'));
-					// display installed versions
-					} else {
-						console.log(chalk.white.bold.underline('The following versions are available offline:\n'));
-						util.listVersions(opts, versions);
-						console.log('');
-					}
-					process.exit(0);
-				}
-				return callback(errorlib.createError('com.appcelerator.install.use.download.error',err.message||String(err)));
-			}
-			if (!result) { return callback(errorlib.createError('com.appcelerator.install.download.server.unavailable')); }
-			debug('versions returned from registry:', result);
-			if (result && result.key) {
-				result = result[result.key];
-			}
-			if (getLatest) {
-				if (!result.length) {
-					console.log(chalk.red('No versions are current deployed. Please check back in a few minutes.'));
-					process.exit(1);
-				}
-				var latest = result[0].version;
-				return use(opts, callback, latest);
-			}
-			var theversion = util.getActiveVersion();
-			// Is this JSON output ?
-			if ('json' === util.parseOpts(opts).o) {
-				obj = util.getVersionJson(result);
-				console.log(JSON.stringify(obj, null, '\t'));
-			} else if (result) {
-				console.log(chalk.white.bold.underline('The following versions are available:\n'));
-				util.listVersions(opts, result);
-				console.log('');
-			}
-			else {
-				console.log('No results returned. Make sure you are online.');
-			}
-			process.exit(0);
-		});
-	}
-	else {
+	debug('use called with args %o, getLatest=%d', args, getLatest);
+
+	if (args.length > 1 && !getLatest) {
 		var version = opts.version = wantVersion || args[1];
 		// see if we have this version
 		installBin = util.getInstallBinary(opts, version);
 		// we already have this version, so we just need to write our version file and exit
 		if (installBin && !opts.force) {
-			debug('making %s your active version, dir %s',version,installBin);
+			debug('making %s your active version, dir %s', version, installBin);
 			util.writeVersion(version);
-			console.log(chalk.yellow(version)+" is now your active version");
+			console.log(chalk.yellow(version) + " is now your active version");
 			process.exit(0);
 		}
 		opts.use = true;
 		// otherwise, we didn't find it, fall through so we can install it
 		return callback();
 	}
+
+	util.startSpinner();
+	var latestUrl = util.makeURL(opts, '/api/appc/latest');
+	util.requestJSON(latestUrl, function (err, latestVersion) {
+		var url = util.makeURL(opts, '/api/appc/list');
+		util.requestJSON(url, function (err, result) {
+			util.stopSpinner();
+			if (err) {
+				// if already an AppCError just return it
+				if (err.name === 'AppCError') {
+					return callback(err);
+				}
+				handleOffline(err, opts, getLatest);
+				return callback(errorlib.createError('com.appcelerator.install.use.download.error', err.message || String(err)));
+			}
+			if (!result) {
+				return callback(errorlib.createError('com.appcelerator.install.download.server.unavailable'));
+			}
+			debug('versions returned from registry:', result);
+			if (result && result.key) {
+				result = result[result.key];
+			}
+			opts.latest = findLatest(result, latestVersion);
+			if (getLatest) {
+				if (!result.length) {
+					console.log(chalk.red('No versions are current deployed. Please check back in a few minutes.'));
+					process.exit(1);
+				}
+				return use(opts, callback, opts.latest);
+			}
+			var theversion = util.getActiveVersion();
+			// Is this JSON output ?
+			if ('json' === util.parseOpts(opts).o) {
+				obj = util.getVersionJson(opts, result);
+				console.log(JSON.stringify(obj, null, '\t'));
+			} else if (result) {
+				console.log(chalk.white.bold.underline('The following versions are available:\n'));
+				util.listVersions(opts, result);
+				console.log('');
+			} else {
+				console.log('No results returned. Make sure you are online.');
+			}
+			process.exit(0);
+		});
+	});
+}
+
+function handleOffline(err, opts, getLatest) {
+	// looks like we are offline
+	if (err.code === 'ENOTFOUND' || err.code === 'ENOENT') {
+		var versions = util.getInstalledVersions();
+		// set active version as latest installed version
+		if (getLatest) {
+			latest = versions[0];
+			installBin = util.getInstallBinary(opts, latest);
+			if (installBin) {
+				debug('making %s your active version, dir %s', latest, installBin);
+				util.writeVersion(latest);
+				console.log(chalk.yellow(latest) + " is now your active version");
+			}
+			// json output
+		} else if ('json' === util.parseOpts(opts).o) {
+			obj = util.getVersionJson(versions);
+			console.log(JSON.stringify(obj, null, '\t'));
+			// display installed versions
+		} else {
+			console.log(chalk.white.bold.underline('The following versions are available offline:\n'));
+			util.listVersions(opts, versions);
+			console.log('');
+		}
+		process.exit(0);
+	}
+}
+
+function findLatest(listResult, latestVerResult) {
+	var latest = listResult[0].version;
+	// Fetch the details from latestVersion payload.
+	if (latestVerResult) {
+		if (latestVerResult.key) {
+			latestVerResult = latestVerResult[latestVerResult.key];
+		}
+		if (latestVerResult.length > 0) {
+			latest = latestVerResult[0].version;
+		}
+	}
+	return latest;
 }
 
 module.exports = use;

--- a/lib/util.js
+++ b/lib/util.js
@@ -175,10 +175,17 @@ function listVersions (opts, versions) {
 		return;
 	}
 	var activeVersion = getActiveVersion();
+
+	// If we don't find latest version from api/appc/list endpoint, then inject the latest version into the list.
+	var versionsList = Object.keys(versions).map(function(value, index){ return versions[index].version; });
+	if (versionsList.indexOf(opts.latest) === -1) {
+		versions.push(opts.latest);
+	}
+
 	versions.forEach(function(entry){
 		var ver = entry.version ? entry.version : entry,
 			suffix = getInstallBinary(opts, ver) ? 'Installed' : 'Not Installed';
-		if (versions.latest === ver) {
+		if (opts.latest === ver) {
 			suffix += chalk.white.bold(' (Latest)');
 		}
 		if (activeVersion && activeVersion === ver) {
@@ -192,20 +199,18 @@ function listVersions (opts, versions) {
 /**
  * return json object of versions
  */
-function getVersionJson (versions) {
+function getVersionJson (opts, versions) {
 	var activeVersion = getActiveVersion(),
 		obj = {
 			versions: [],
-			latest: undefined,
+			latest: opts.latest,
 			active: activeVersion
 		};
 	if (Array.isArray(versions)) {
 		if (versions[0].version) {
 			obj.versions = Object.keys(versions).map(function(value, index){ return versions[index].version; });
-			obj.latest = versions[0].version;
 		} else {
 			obj.versions = versions;
-			obj.latest = versions[0];
 		}
 	}
 	return obj;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "4.1.0-1",
+  "version": "4.2.0-1",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",


### PR DESCRIPTION
Modified ``appc use`` command to make sure it queries for latest version of appc-cli from registry. If versions are not available, then it falls back to the 1st top element in the returned list of packages.