### PR TITLE
CLI-834 Serious problem of consumption of RAM

### DIFF
--- a/bin/appc
+++ b/bin/appc
@@ -193,9 +193,15 @@ function subprocess(cmd, installBin) {
 	});
 
 	// propagate signals to child process
-	['SIGTERM', 'SIGUSR1', 'SIGUSR2', 'SIGINT', 'SIGHUP', 'SIGQUIT', 'SIGABRT'].forEach(function (name) {
+	['SIGTERM', 'SIGUSR1', 'SIGUSR2', 'SIGINT', 'SIGHUP', 'SIGQUIT', 'SIGABRT', 'exit'].forEach(function (name) {
 		process.on(name, function () {
-			child.kill(name);
+			if (name === 'exit') {
+				child.kill();
+				process.exit(arguments[0]);
+			} else {
+				child.kill(name);
+				process.exit();
+			}
 		});
 	});
 }

--- a/lib/run.js
+++ b/lib/run.js
@@ -54,6 +54,7 @@ function run (installBin, additionalArgs, cb, dontexit) {
 				process.exit(arguments[0]);
 			} else {
 				child.kill(name);
+				process.exit();
 			}
 		});
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "4.2.1-0",
+  "version": "4.2.1-1",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",


### PR DESCRIPTION
This PR tries to address couple of issues 

- When user hit Terminate button after app lunch on Studio, then issues ``kill <appc-pid>``, but that doesn't kill any of the appc-cli processes.
- Liveview doesn't work from 2nd launch, as the processes are holding up from previous launch.

There are still different set of changes in appc-cli or appc-cli-titanium repo, trying to clean up titanium process.