### PR TITLE
CLI-842 Improve performance of appc -v command

### DIFF
--- a/bin/appc
+++ b/bin/appc
@@ -210,6 +210,7 @@ function main() {
 
 	var subcommand = args[0];
 	debug('main subcommand %s',subcommand);
+	opts.version = opts.version || opts.v;
 
 	// see if this is a use command
 	if (process.argv.length > 2) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "4.2.1-3",
+  "version": "4.2.1-4",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",


### PR DESCRIPTION
The option ``-v`` is not considered by our parsing code, and it is always ignored to load into ``opts``. So, whenever we execute ``appc -v`` command, it runs through software.appcelerator.com/api/appc/list results, and then, prints the version. That results in very slow response of the command when the registry server is not responsive. Since Studio runs this command a lot of times, these changes will improve performance of Studio as well.