### PR TITLE
CLI-950 ensure that subprocess gets proper signal and exits

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -84,7 +84,6 @@ function run(installBin, additionalArgs, cb, dontexit) {
 						process.exit(arguments[0]);
 					} else {
 						child.kill(name);
-						process.exit();
 					}
 				});
 			});

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "appcelerator",
-  "version": "4.2.4-0",
+  "version": "4.2.4-1",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "preferGlobal": true,
   "bin": {
     "appc": "./bin/appc",


### PR DESCRIPTION
The problem is that if we capture a signal such as SIGTERM and then process.exit after receiving it, a subprocess or subsequent process.on handler cannot handle it.  this is easily exposed running the arrow unit test suite with the 5.2.0 release + latest appcelerator npm.

this change means we simply wait for the exit to be send and only exit then.