### PR TITLE
Bump version 4.2.10-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "4.2.9-4",
+  "version": "4.2.10-0",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",


### PR DESCRIPTION
Package version should be bump since we already published 4.2.9 with appc@6.2.0.