### PR TITLE
[CLI-939] Check if module is compatible with OS before attempting to install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 tmp
 coverage
 junit_report.xml
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.enable": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "eslint.enable": false
-}

--- a/lib/install.js
+++ b/lib/install.js
@@ -20,7 +20,8 @@ var fs = require('fs'),
 	tar = require('tar'),
 	chalk = require('chalk'),
 	debug = require('debug')('appc:install'),
-	exec = require('child_process').exec;
+	exec = require('child_process').exec,
+	checkPlatform = require('npm-install-checks').checkPlatform;
 
 /**
  * tar gunzip
@@ -194,34 +195,48 @@ function compileNativeModules(dir, callback) {
 						todir = path.dirname(dir),
 						todirname = path.basename(path.dirname(todir)),
 						installdir = path.join(dir, '..', '..'),
+						shouldInstall = true,
 						version;
 					/*jshint -W083 */
 					if (fs.existsSync(dir)) {
 						var pkg = path.join(dir, 'package.json');
 						if (fs.existsSync(pkg)) {
 							// make sure we install the exact version
-							version = JSON.parse(fs.readFileSync(pkg)).version;
+							var pkgcontents = JSON.parse(fs.readFileSync(pkg));
+							version = pkgcontents.version;
 							debug('found version %s', version);
 							version = '@' + version;
+							checkPlatform(pkgcontents, false, function (err) {
+								if (err) {
+									debug('module %s is not supported on the current os %s, not installing it', name, process.platform);
+									shouldInstall = false;
+								}
+							});
 						}
 						debug('rmdir %s', dir);
 						util.rmdirSyncRecursive(dir);
 					}
-					var cmd = 'npm install ' + name + version + ' --production';
-					debug('exec: %s in dir %s', cmd, installdir);
-					util.waitMessage('└ ' + chalk.cyan(todirname + '/' + name) + ' ');
-					exec(cmd, {cwd: installdir}, function (err, stdout, stderr) {
-						if (err) {
-							util.infoMessage('Failed to install ' + name + version + '; it may not support your current OS.');
-							debug('error during %s, was: %o', cmd, err);
-							debug('stdout: %s', stdout);
-							debug('stderr: %s', stderr);
-							doNext();
-						} else {
-							util.okMessage();
-							doNext();
-						}
-					});
+					if (shouldInstall) {
+						var cmd = 'npm install ' + name + version + ' --production';
+						debug('exec: %s in dir %s', cmd, installdir);
+						util.waitMessage('└ ' + chalk.cyan(todirname + '/' + name) + ' ');
+						exec(cmd, {cwd: installdir}, function (err, stdout, stderr) {
+							if (err) {
+								util.infoMessage('Failed to install ' + name + version + '; it may not support your current OS.');
+								debug('error during %s, was: %o', cmd, err);
+								debug('stdout: %s', stdout);
+								debug('stderr: %s', stderr);
+								doNext();
+							} else {
+								util.okMessage();
+								doNext();
+							}
+						});
+					} else {
+						util.infoMessage('└ not installing ' + chalk.cyan(todirname + '/' + name) + ' as it does not support the current OS ');
+						doNext();
+					}
+
 				} else {
 					callback();
 				}

--- a/lib/install.js
+++ b/lib/install.js
@@ -232,11 +232,7 @@ function compileNativeModules(dir, callback) {
 								doNext();
 							}
 						});
-					} else {
-						util.infoMessage('└ not installing ' + chalk.cyan(todirname + '/' + name) + ' as it does not support the current OS ');
-						doNext();
 					}
-
 				} else {
 					callback();
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2241,6 +2241,14 @@
         "validate-npm-package-license": "3.0.1"
       }
     },
+    "npm-install-checks": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+      "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
+      "requires": {
+        "semver": "5.4.1"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "async": "^1.5.0",
     "chalk": "0.5.1",
     "debug": "^2.1.1",
+    "npm-install-checks": "^3.0.0",
     "pac-proxy-agent": "^2.0.0",
     "progress": "1.1.8",
     "request": "^2.55.0",


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/CLI-939

- Before running an npm install to recompile during an `appc use`, check if the module is compatible with the OS. If not don't install, avoiding an error

Question is whether we want to log it as I do below? Or just ignore it?

````
λ appc use 6.3.0 --force
Before you can continue, the latest Appcelerator software update needs to be downloaded.

Finding version 6.3.0  OK
Validating security checksum OK
Installing  OK
Compiling platform native modules
└ alloy/deasync OK
└ external-editor/spawn-sync  OK
└ bunyan/dtrace-provider  OK
└ bunyan/dtrace-provider  OK
└ arrow-flow/jsonpath  OK
└ bunyan/dtrace-provider  OK
└ ldapjs/dtrace-provider  OK
Installed!!
````