### PR TITLE
[CLI-1326] Update targz method

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -28,11 +28,12 @@ var fs = require('fs'),
  */
 function targz(sourceFile, destination, callback) {
 	debug('targz source=%s, dest=%s', sourceFile, destination);
-	fs.createReadStream(sourceFile)
-		.pipe(zlib.createGunzip())
-		.pipe(tar.extract({cwd: destination}))
-		.on('error', function (err) { callback(err); })
-		.on('end', function () { callback(null); });
+	tar.x({
+		file: sourceFile,
+		cwd: destination
+	}, function (err) {
+		callback(err);
+	});
 }
 
 /**


### PR DESCRIPTION
- Update and simplify the `targz` method to only utilize the `tar` module

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-1326)