### PR TITLE
[CLI-1330] Only parse as a value if the previous argument was not an option

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -423,6 +423,7 @@ function parseArgs(opts) {
 	var args = [];
 	for (var c = 2; c < process.argv.length; c++) {
 		var arg = process.argv[c];
+		var previous = process.argv[c-1];
 		if (optionRE.test(arg)) {
 			var match = optionRE.exec(arg),
 				name = match[1],
@@ -432,7 +433,7 @@ function parseArgs(opts) {
 				c++;
 			}
 			continue;
-		} else {
+		} else if (!optionRE.test(previous)) {
 			args.push(arg);
 		}
 	}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/CLI-1330

To test:

Run `appc use --prerelease -o json` it should output the version info and not attempt to download a cli core