### PR TITLE
feat: use npm rebuild instead of npm install when installing a CLI core

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -20,7 +20,9 @@ var fs = require('fs'),
 	tar = require('tar'),
 	chalk = require('chalk'),
 	debug = require('debug')('appc:install'),
-	exec = require('child_process').exec;
+	exec = require('child_process').exec,
+	semver = require('semver'),
+	checkPlatform = require('npm-install-checks').checkPlatform;
 
 /**
  * tar gunzip
@@ -180,24 +182,92 @@ function findAllNativeModules(dir, check) {
  * run npm install on all compiled native modules so that they will be
  * correctly compiled for the installed platform (vs. the platform we used to upload)
  */
-function compileNativeModules(dir, callback) {
+function compileNativeModules(dir, cliVersion, callback) {
 	debug('compileNativeModules %s', dir);
 	process.nextTick(function () {
-		util.waitMessage('Compiling platform native modules');
-		var cmd = 'npm rebuild';
-		debug('exec: %s in dir %s', cmd, dir);
-		exec(cmd, {cwd: dir}, function (err, stdout, stderr) {
-			if (err) {
-				util.infoMessage('Failed to rebuild native modules. Please contact Appcelerator Support at support@appcelerator.com.');
-				debug('error during %s, was: %o', cmd, err);
-				debug('stdout: %s', stdout);
-				debug('stderr: %s', stderr);
-				callback();
+		// Strip off any prerelease suffixes on our cliVersion
+		const cleanVersion = semver.coerce(cliVersion);
+		// If 7.1.0 CLI or higher then we can use npm rebuild
+		if (semver.gte(cleanVersion, '7.1.0')) {
+			util.waitMessage('Compiling platform native modules');
+			var cmd = 'npm rebuild';
+			debug('exec: %s in dir %s', cmd, dir);
+			exec(cmd, {cwd: dir}, function (err, stdout, stderr) {
+				if (err) {
+					util.infoMessage('Failed to rebuild native modules. Please contact Appcelerator Support at support@appcelerator.com.');
+					debug('error during %s, was: %o', cmd, err);
+					debug('stdout: %s', stdout);
+					debug('stderr: %s', stderr);
+					callback();
+				} else {
+					util.okMessage();
+					callback();
+				}
+			});
+		} else {
+			// For pre-7.1.0 CLIs we need to still use the full install due to missing deps
+			var dirs = findAllNativeModules(dir),
+				finished = 0;
+			if (dirs.length) {
+				util.waitMessage('Compiling platform native modules\n');
+				// run them serially so we don't run into npm lock issues
+				var doNext = function doNext() {
+					var dir = dirs[finished++];
+					if (dir) {
+						var name = path.basename(dir),
+							todir = path.dirname(dir),
+							todirname = path.basename(path.dirname(todir)),
+							installdir = path.join(dir, '..', '..'),
+							shouldInstall = true,
+							version;
+						/*jshint -W083 */
+						if (fs.existsSync(dir)) {
+							var pkg = path.join(dir, 'package.json');
+							if (fs.existsSync(pkg)) {
+								// make sure we install the exact version
+								var pkgcontents = JSON.parse(fs.readFileSync(pkg));
+								version = pkgcontents.version;
+								debug('found version %s', version);
+								version = '@' + version;
+								checkPlatform(pkgcontents, false, function (err) {
+									if (err) {
+										debug('module %s is not supported on the current os %s, not installing it', name, process.platform);
+										shouldInstall = false;
+									}
+								});
+							}
+							debug('rmdir %s', dir);
+							util.rmdirSyncRecursive(dir);
+						}
+						if (shouldInstall) {
+							var cmd = 'npm install ' + name + version + ' --production';
+							debug('exec: %s in dir %s', cmd, installdir);
+							util.waitMessage('└ ' + chalk.cyan(todirname + '/' + name) + ' ');
+							exec(cmd, {cwd: installdir}, function (err, stdout, stderr) {
+								if (err) {
+									util.infoMessage('Failed to install ' + name + version + '; it may not support your current OS.');
+									debug('error during %s, was: %o', cmd, err);
+									debug('stdout: %s', stdout);
+									debug('stderr: %s', stderr);
+									doNext();
+								} else {
+									util.okMessage();
+									doNext();
+								}
+							});
+						} else {
+							doNext();
+						}
+					} else {
+						callback();
+					}
+				};
+				doNext();
 			} else {
-				util.okMessage();
+				debug('none found');
 				callback();
 			}
-		});
+		}
 	});
 }
 
@@ -369,7 +439,7 @@ function install(installDir, opts, cb) {
 				}
 
 				// compile any native modules found
-				compileNativeModules(dir, function (err) {
+				compileNativeModules(dir, version, function (err) {
 
 					if (err) {
 						cleanupInstall();

--- a/lib/install.js
+++ b/lib/install.js
@@ -20,8 +20,7 @@ var fs = require('fs'),
 	tar = require('tar'),
 	chalk = require('chalk'),
 	debug = require('debug')('appc:install'),
-	exec = require('child_process').exec,
-	checkPlatform = require('npm-install-checks').checkPlatform;
+	exec = require('child_process').exec;
 
 /**
  * tar gunzip

--- a/lib/install.js
+++ b/lib/install.js
@@ -184,67 +184,21 @@ function findAllNativeModules(dir, check) {
 function compileNativeModules(dir, callback) {
 	debug('compileNativeModules %s', dir);
 	process.nextTick(function () {
-		var dirs = findAllNativeModules(dir),
-			finished = 0;
-		if (dirs.length) {
-			util.waitMessage('Compiling platform native modules\n');
-			// run them serially so we don't run into npm lock issues
-			var doNext = function doNext() {
-				var dir = dirs[finished++];
-				if (dir) {
-					var name = path.basename(dir),
-						todir = path.dirname(dir),
-						todirname = path.basename(path.dirname(todir)),
-						installdir = path.join(dir, '..', '..'),
-						shouldInstall = true,
-						version;
-					/*jshint -W083 */
-					if (fs.existsSync(dir)) {
-						var pkg = path.join(dir, 'package.json');
-						if (fs.existsSync(pkg)) {
-							// make sure we install the exact version
-							var pkgcontents = JSON.parse(fs.readFileSync(pkg));
-							version = pkgcontents.version;
-							debug('found version %s', version);
-							version = '@' + version;
-							checkPlatform(pkgcontents, false, function (err) {
-								if (err) {
-									debug('module %s is not supported on the current os %s, not installing it', name, process.platform);
-									shouldInstall = false;
-								}
-							});
-						}
-						debug('rmdir %s', dir);
-						util.rmdirSyncRecursive(dir);
-					}
-					if (shouldInstall) {
-						var cmd = 'npm install ' + name + version + ' --production';
-						debug('exec: %s in dir %s', cmd, installdir);
-						util.waitMessage('└ ' + chalk.cyan(todirname + '/' + name) + ' ');
-						exec(cmd, {cwd: installdir}, function (err, stdout, stderr) {
-							if (err) {
-								util.infoMessage('Failed to install ' + name + version + '; it may not support your current OS.');
-								debug('error during %s, was: %o', cmd, err);
-								debug('stdout: %s', stdout);
-								debug('stderr: %s', stderr);
-								doNext();
-							} else {
-								util.okMessage();
-								doNext();
-							}
-						});
-					} else {
-						doNext();
-					}
-				} else {
-					callback();
-				}
-			};
-			doNext();
-		} else {
-			debug('none found');
-			callback();
-		}
+		util.waitMessage('Compiling platform native modules');
+		var cmd = 'npm rebuild';
+		debug('exec: %s in dir %s', cmd, dir);
+		exec(cmd, {cwd: dir}, function (err, stdout, stderr) {
+			if (err) {
+				util.infoMessage('Failed to rebuild native modules. Please contact Appcelerator Support at support@appcelerator.com.');
+				debug('error during %s, was: %o', cmd, err);
+				debug('stdout: %s', stdout);
+				debug('stderr: %s', stderr);
+				callback();
+			} else {
+				util.okMessage();
+				callback();
+			}
+		});
 	});
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "4.2.14-1",
+  "version": "4.2.14-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1490,7 +1491,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -1912,6 +1914,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -1985,7 +1988,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -2350,6 +2354,14 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "npm-install-checks": {
@@ -2358,6 +2370,13 @@
       "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
       "requires": {
         "semver": "^2.3.0 || 3.x || 4 || 5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "number-is-nan": {
@@ -2628,6 +2647,12 @@
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true,
           "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
         }
       }
     },
@@ -2747,7 +2772,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -2860,9 +2886,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
     },
     "setprototypeof": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "4.2.14-1",
+  "version": "4.2.14-2",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "async": "^1.5.0",
     "chalk": "0.5.1",
     "debug": "^2.1.1",
-    "npm-install-checks": "^3.0.0",
     "pac-proxy-agent": "^3.0.0",
     "progress": "1.1.8",
     "request": "^2.87.0",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
     "async": "^1.5.0",
     "chalk": "0.5.1",
     "debug": "^2.1.1",
+    "npm-install-checks": "^3.0.0",
     "pac-proxy-agent": "^3.0.0",
     "progress": "1.1.8",
     "request": "^2.87.0",
-    "semver": "~5.4.1",
+    "semver": "^6.0.0",
     "tar": "^4.4.4",
     "which": "1.0.8"
   },


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/CLI-1346

There appears to be no reason for the install process to run `npm install <package>@<version>` when downloading a CLI. This change instead runs `npm rebuild` in the root of the CLI core (similar to what's done on a node version change). Locally for me on MacOS this takes an `appc use <version>` from around 2 minutes to 30 seconds, but I imagine the real speedup will be for Windows users