### PR TITLE
Ensure daemon is stopped in all instances

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -12,11 +12,9 @@
  */
 var fs = require('fs'),
 	path = require('path'),
-	urllib = require('url'),
 	download = require('./download'),
 	util = require('./util'),
 	errorlib = require('./error'),
-	zlib = require('zlib'),
 	tar = require('tar'),
 	chalk = require('chalk'),
 	debug = require('debug')('appc:install'),
@@ -475,8 +473,11 @@ function install(installDir, opts, cb) {
 					// write current process versions to package dir
 					util.writeVersions(installDir);
 
-					// if this is a use or setup, we don't run, we just return
-					if (opts.use) { return cb && cb(null, installDir, version, installBin); }
+					// if this is a use we don't run, we just return
+					if (opts.use) {
+						util.killDaemon(version, installBin);
+						return cb && cb(null, installDir, version, installBin);
+					}
 
 					debug('running %s', installBin);
 

--- a/lib/use.js
+++ b/lib/use.js
@@ -10,10 +10,7 @@
 var util = require('./util'),
 	errorlib = require('./error'),
 	debug = require('debug')('appc:use'),
-	chalk = require('chalk'),
-	exec = require('child_process').exec,
-	fs = require('fs'),
-	path = require('path');
+	chalk = require('chalk');
 
 function use(opts, callback, wantVersion) {
 	var args = util.parseArgs(opts),
@@ -28,17 +25,10 @@ function use(opts, callback, wantVersion) {
 		// we already have this version, so we just need to write our version file and exit
 		if (installBin && !opts.force) {
 			debug('making %s your active version, dir %s', version, installBin);
-
-			var pkgFile = path.join(util.getInstallDir(), version, 'package', 'package.json');
-			var pkg = fs.existsSync(pkgFile) && require(pkgFile);
-			if (pkg && 'appcd' in pkg.dependencies) {
-				debug('stop appcd');
-				return exec(installBin + ' appcd stop', function (err, stdout, stderr) {
-					switchCoreAndOut(version);
-				});
-			}
-
-			switchCoreAndOut(version);
+			util.writeVersion(version);
+			util.killDaemon(version, installBin);
+			console.log(chalk.yellow(version) + ' is now your active version');
+			process.exit(0);
 		}
 		opts.use = true;
 		// otherwise, we didn't find it, fall through so we can install it
@@ -100,12 +90,6 @@ function use(opts, callback, wantVersion) {
 			process.exit(0);
 		});
 	});
-}
-
-function switchCoreAndOut(version) {
-	util.writeVersion(version);
-	console.log(chalk.yellow(version) + ' is now your active version');
-	process.exit(0);
 }
 
 function handleOffline(err, opts, getLatest) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1068,7 +1068,7 @@ function killDaemon(version, installBin) {
 	if (pkg && 'appcd' in pkg.dependencies) {
 		debug('stop appcd');
 		try {
-			execSync(`${installBin} appcd stop`);
+			execSync(installBin + ' appcd stop');
 		} catch (error) {
 			// ignore
 			debug('error killing the daemon');

--- a/lib/util.js
+++ b/lib/util.js
@@ -1065,6 +1065,9 @@ function outputInfo(msg, isJSON) {
 function killDaemon(version, installBin) {
 	var pkgFile = path.join(getInstallDir(), version, 'package', 'package.json');
 	var pkg = fs.existsSync(pkgFile) && require(pkgFile);
+	if (isWindows()) {
+		installBin = '"' + process.execPath + '" "' + installBin + '"';
+	}
 	if (pkg && 'appcd' in pkg.dependencies) {
 		debug('stop appcd');
 		try {

--- a/lib/util.js
+++ b/lib/util.js
@@ -18,7 +18,8 @@ var fs = require('fs'),
 	spinner,
 	spriteIndex = 0,
 	cachedConfig,
-	sprite = '/-\\|';
+	sprite = '/-\\|',
+	execSync = require('child_process').execSync;
 
 var MAX_RETRIES = exports.MAX_RETRIES = 5;
 var CONN_TIMEOUT = 10000;
@@ -1061,6 +1062,21 @@ function outputInfo(msg, isJSON) {
 	exports.stdout.write(msg);
 }
 
+function killDaemon(version, installBin) {
+	var pkgFile = path.join(getInstallDir(), version, 'package', 'package.json');
+	var pkg = fs.existsSync(pkgFile) && require(pkgFile);
+	if (pkg && 'appcd' in pkg.dependencies) {
+		debug('stop appcd');
+		try {
+			execSync(`${installBin} appcd stop`);
+		} catch (error) {
+			// ignore
+			debug('error killing the daemon');
+			debug(error);
+		}
+	}
+}
+
 exports.getAppcDir = getAppcDir;
 exports.getHomeDir = getHomeDir;
 exports.getCacheDir = getCacheDir;
@@ -1105,3 +1121,4 @@ exports.writeVersions = writeVersions;
 exports.isModuleVersionChanged = isModuleVersionChanged;
 exports.getPackageNodeVersion = getPackageNodeVersion;
 exports.outputInfo = outputInfo;
+exports.killDaemon = killDaemon;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "4.2.14",
+  "version": "4.2.15-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "4.2.14",
+  "version": "4.2.15-1",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",
@@ -53,5 +53,8 @@
   },
   "engines": {
     "node": ">=8.0.0"
+  },
+  "publishConfig": {
+    "tag": "next"
   }
 }

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -544,7 +544,7 @@ describe('util', function () {
 		});
 
 		(!process.env.TRAVIS ? it : it.skip)('should updateCheck show msg', function (next) {
-			var config = util.readConfig();
+			var config = util.readConfig() || {};
 			config.lastUpdateCheck = 0;
 			util.setCachedConfig(config);
 
@@ -593,7 +593,7 @@ describe('util', function () {
 		});
 
 		(!process.env.TRAVIS ? it : it.skip)('should updateCheck do not show msg', function (next) {
-			var config = util.readConfig();
+			var config = util.readConfig() || {};
 			config.lastUpdateCheck = 0;
 			util.setCachedConfig(config);
 


### PR DESCRIPTION
There are currently two instances where the daemon is not correctly stopped when installing/selecting a CLI

* `appc use <version>` when Appc Studio is open and restarts the daemon in the previous version, as we kill the daemon _before_ writing `<version>` to disk as the active cli so Studio will restart the daemon from the previous version - 482d280c55894d1e1219784a9205b8f585fef3a2 
	* Fix is to write the version before killing the daemon
* `appc use <version>` where version has to be downloaded - e5828d9ed897ec9cf98413bee9a8086c230ff459
	* Fix is to kill the daemon in this code path

