### PR TITLE
test: allow readConfig to be mocked

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -510,7 +510,7 @@ function makeURL(opts, urlpath) {
 		}
 	}
 	if (!baseurl) {
-		var config = readConfig();
+		var config = exports.readConfig();
 		if (config && config.registry) {
 			baseurl = config.registry;
 		} else if (config && (config.defaultEnvironment === 'preproduction' || config.environmentName === 'preproduction')) {

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -178,7 +178,12 @@ describe('util', function () {
 		});
 
 		it('parse using default', function () {
+			const originalReadConfig = util.readConfig;
+			util.readConfig = function readConfig () {
+				return null;
+			};
 			should(util.makeURL({}, 'foo')).be.equal('https://registry.platform.axway.com/foo');
+			util.readConfig = originalReadConfig;
 		});
 
 	});


### PR DESCRIPTION
This allows us to ensure that we take the expected codepath during tests, otherwise we're entirely dependent on a users local config