### PR TITLE
fix(use): use spawn to avoid max buffer error

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -18,7 +18,7 @@ var fs = require('fs'),
 	tar = require('tar'),
 	chalk = require('chalk'),
 	debug = require('debug')('appc:install'),
-	exec = require('child_process').exec, // eslint-disable-line security/detect-child-process
+	{ exec, spawn } = require('child_process'), // eslint-disable-line security/detect-child-process
 	semver = require('semver'),
 	checkPlatform = require('npm-install-checks').checkPlatform;
 
@@ -209,18 +209,36 @@ function compileNativeModules(dir, cliVersion, callback) {
 			util.waitMessage('Compiling platform native modules');
 			var cmd = 'npm rebuild';
 			var rebuildDir = path.join(dir, 'package');
-			debug('exec: %s in dir %s', cmd, rebuildDir);
-			exec(cmd, { cwd: rebuildDir }, function (err, stdout, stderr) {
-				if (err) {
+			let child;
+			let stderr = '';
+			let stdout = '';
+			const rebuildOpts = { cwd: rebuildDir };
+			debug('spawn: %s in dir %s', cmd, rebuildDir);
+
+			if (/^win/.test(process.platform)) {
+				child = spawn(process.env.comspec, [ '/c', 'npm' ].concat([ 'rebuild' ]), rebuildOpts);
+			} else {
+				child = spawn('npm', [ 'rebuild' ], rebuildOpts);
+			}
+
+			child.stderr.on('data', (chunk) => {
+				stderr += chunk.toString();
+			});
+
+			child.stdout.on('data', (chunk) => {
+				stdout += chunk.toString();
+			});
+
+			child.on('exit', (code) => {
+				if (code) {
 					util.infoMessage('Failed to rebuild native modules. Please contact Appcelerator Support at support@appcelerator.com.');
-					debug('error during %s, was: %o', cmd, err);
+					debug('error during %s', cmd);
 					debug('stdout: %s', stdout);
 					debug('stderr: %s', stderr);
-					callback();
 				} else {
 					util.okMessage();
-					callback();
 				}
+				callback();
 			});
 		} else {
 			// For pre-7.1.0 CLIs we need to still use the full install due to missing deps
@@ -522,9 +540,7 @@ function install(installDir, opts, cb) {
 				});
 			});
 		});
-
 	});
-
 }
 
 module.exports = install;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "5.0.0-3",
+  "version": "5.0.0-4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "5.0.0-3",
+  "version": "5.0.0-4",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",


### PR DESCRIPTION
Fixes CLI-1389

Mostly just a copy paste of https://github.com/appcelerator/appc-install/blob/master/lib/run.js#L64-L80 with just collecting stdout/stderr