### PR TITLE
Skip appcd postinstall script, bump min node version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 library 'pipeline-library'
 
 buildNPMPackage {
-  // nodeVersion = '6.9.5'
+  nodeVersion = '12.18.0'
   // tags, publishes, updates JIRA only for master branch builds.
   publishAsTagOnly = false // DOES NOT UPDATE 'latest' tag on NPM when published!
   // records unit test and code coverage results

--- a/lib/install.js
+++ b/lib/install.js
@@ -212,7 +212,7 @@ function compileNativeModules(dir, cliVersion, callback) {
 			let child;
 			let stderr = '';
 			let stdout = '';
-			const rebuildOpts = { cwd: rebuildDir };
+			const rebuildOpts = { cwd: rebuildDir, env: { ...process.env, APPCD_SKIP_POSTINSTALL: 1 } };
 			debug('spawn: %s in dir %s', cmd, rebuildDir);
 
 			if (/^win/.test(process.platform)) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1221,6 +1221,7 @@ function runAppcdCommand (command, installBin) {
 
 function checkNodeVersion (supportedNodeRange) {
 	if (!semver.satisfies(process.version, supportedNodeRange)) {
+		chalk = chalk || require('chalk');
 		console.log(chalk.cyan('Appcelerator Command-Line Interface'));
 		console.log('Copyright (c) 2014-' + (new Date().getFullYear()) + ', Appcelerator, Inc.  All Rights Reserved.');
 		console.log('');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "5.1.0-2",
+  "version": "6.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2428,9 +2428,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -2457,11 +2457,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "tar": "^4.4.13"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "tag": "next"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcelerator",
-  "version": "5.1.0-2",
+  "version": "6.0.0-1",
   "description": "Appcelerator Platform Software installer",
   "main": "index.js",
   "author": "Jeff Haynie",


### PR DESCRIPTION
This will stop appcd from stopping the daemon and installing plugins whenever we need to recompile
the native modules, hopefully speeding the process up slightly.

Closes CLI-1408 and CLI-1407